### PR TITLE
Remove SOL/USDT debug print

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -49,7 +49,7 @@ async def webhook(request: Request, payload: WebhookPayload):
     try:
         exchange = await get_exchange(payload.exchange, payload.apiKey, payload.secret)
         markets = await exchange.load_markets()
-        print(markets['SOL/USDT'])  # should show type: 'future'
+        logger.debug(markets.get(payload.symbol))
 
         # order = await exchange.create_limit_order(
         #     symbol=payload.symbol,


### PR DESCRIPTION
## Summary
- drop SOL/USDT print statement
- log selected market info with `logger.debug`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6846dc7925608331a7f2ba73c50e93aa