### PR TITLE
Replace print statements with logger

### DIFF
--- a/simulate_tradingview.py
+++ b/simulate_tradingview.py
@@ -1,6 +1,9 @@
 import requests
 import time
 import json
+from app.utils import setup_logger
+
+logger = setup_logger("simulate_tradingview")
 
 url = "http://127.0.0.1:8000/webhook"
 payload = {
@@ -23,6 +26,6 @@ start = time.monotonic()
 response = requests.post(url, data=json.dumps(payload), headers=headers)
 end = time.monotonic()
 
-print(f"Status Code: {response.status_code}")
-print(f"Response Time: {end - start:.4f} seconds")
-print("Response Body:", response.json())
+logger.info(f"Status Code: {response.status_code}")
+logger.info(f"Response Time: {end - start:.4f} seconds")
+logger.info("Response Body: %s", response.json())


### PR DESCRIPTION
## Summary
- use `setup_logger` in `simulate_tradingview.py`
- replace print calls with logger

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6846e053905083318494972c85f13014