### PR TITLE
Add SlowAPI rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This project is a production-grade, asynchronous webhook server built with **Fas
 - 📡 **TradingView-compatible**
 - 🧪 **Full async test suite** with `pytest-asyncio` and mocking
 - ☁️ **Heroku deployment ready**
+- 🚦 **Per-IP rate limiting** via `slowapi`
 
 ---
 
@@ -53,6 +54,7 @@ DEFAULT_EXCHANGE=binance
 DEFAULT_API_KEY=your_exchange_api_key
 DEFAULT_API_SECRET=your_exchange_api_secret
 LOG_LEVEL=INFO
+RATE_LIMIT=10/minute
 ```
 
 | Variable           | Description |
@@ -62,6 +64,7 @@ LOG_LEVEL=INFO
 | `DEFAULT_API_KEY`  | Optional fallback key |
 | `DEFAULT_API_SECRET` | Optional fallback secret |
 | `LOG_LEVEL`        | Logging verbosity |
+| `RATE_LIMIT`       | Requests allowed per timeframe |
 
 ---
 

--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -1,0 +1,4 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/app/routes.py
+++ b/app/routes.py
@@ -5,6 +5,8 @@ from typing import Optional
 from pydantic import BaseModel
 import logging
 from ccxt.base.errors import ExchangeError, NetworkError
+from app.rate_limiter import limiter
+from config.settings import settings
 
 router = APIRouter()
 logger = logging.getLogger("webhook_logger")
@@ -35,6 +37,7 @@ class WebhookPayload(BaseModel):
 
 
 @router.post("/webhook")
+@limiter.limit(settings.RATE_LIMIT)
 async def webhook(request: Request, payload: WebhookPayload):
     if "X-Signature" in request.headers:
         if not await verify_signature(request):

--- a/config/settings.py
+++ b/config/settings.py
@@ -14,12 +14,14 @@ class Settings(BaseSettings):
         DEFAULT_API_KEY (str): Fallback API key if not provided in payload.
         DEFAULT_API_SECRET (str): Fallback API secret.
         LOG_LEVEL (str): Logging verbosity (DEBUG, INFO, etc.).
+        RATE_LIMIT (str): Requests allowed per time window (e.g., "10/minute").
     """
     WEBHOOK_SECRET: str
     DEFAULT_EXCHANGE: str
     DEFAULT_API_KEY: str
     DEFAULT_API_SECRET: str
     LOG_LEVEL: str = "INFO"
+    RATE_LIMIT: str = "10/minute"
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/main.py
+++ b/main.py
@@ -2,9 +2,17 @@ from fastapi import FastAPI, Request
 from app.routes import router as webhook_router
 import logging
 from app.utils import setup_logger
+from app.rate_limiter import limiter
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
 app = FastAPI()
 setup_logger()
+
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
 
 app.include_router(webhook_router)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic-settings
 httpx
 pytest
 pytest-asyncio
+slowapi


### PR DESCRIPTION
## Summary
- add slowapi dependency
- expose RATE_LIMIT setting
- configure rate limiter middleware
- limit `/webhook` route per-IP
- document rate limit and new dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6846ecb855b083318e701177e7818e5d