### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        env:
+          WEBHOOK_SECRET: testsecret
+          DEFAULT_EXCHANGE: binance
+          DEFAULT_API_KEY: testkey
+          DEFAULT_API_SECRET: testsecret
+          LOG_LEVEL: INFO
+          RATE_LIMIT: '10/minute'
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow to run tests on Python 3.10

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f8fd64f48331b138887e87d14ecf