### PR TITLE
Validate exchange id

### DIFF
--- a/app/exchange_factory.py
+++ b/app/exchange_factory.py
@@ -29,13 +29,13 @@ async def get_exchange(
     """
     exchange_id = exchange_id.lower()  # 🛠 Normalize input
 
-    try:
-        exchange_class = getattr(ccxt, exchange_id)
-    except AttributeError:
+    if exchange_id not in ccxt.exchanges:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Exchange '{exchange_id}' is not supported by CCXT."
         )
+
+    exchange_class = getattr(ccxt, exchange_id)
 
     api_key = api_key or settings.DEFAULT_API_KEY
     secret = secret or settings.DEFAULT_API_SECRET

--- a/app/routes.py
+++ b/app/routes.py
@@ -81,6 +81,9 @@ async def webhook(request: Request, payload: WebhookPayload):
         logger.warning(f"Validation error: {ve}")
         raise HTTPException(status_code=422, detail=str(ve))
 
+    except HTTPException as http_exc:
+        raise http_exc
+
     except Exception as e:
         logger.exception("Unhandled server error")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -5,7 +5,7 @@ import time
 import json
 import hmac
 import hashlib
-from typing import Optional
+from fastapi import HTTPException
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -113,6 +113,30 @@ async def test_invalid_signature():
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post("/webhook", json=payload, headers=headers)
         assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_exchange_invalid_id():
+    with pytest.raises(HTTPException) as exc:
+        await exchange_factory.get_exchange("nosuch", "k", "s")
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_invalid_exchange_route():
+    payload = {
+        "token": settings.WEBHOOK_SECRET,
+        "exchange": "nosuch",
+        "apiKey": "key",
+        "secret": "secret",
+        "symbol": "BTC/USDT",
+        "side": "buy",
+        "amount": 1,
+        "price": 30000,
+    }
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/webhook", json=payload)
+        assert response.status_code == 400
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- validate `exchange_id` with `ccxt.exchanges`
- allow routes to propagate `HTTPException`
- test invalid exchange IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684711df6f2083318d311d117405a17d