### PR TITLE
Add strict payload validation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, HTTPException, Request, status
 from app.auth import verify_signature, verify_token
 from app.exchange_factory import get_exchange
-from typing import Optional
-from pydantic import BaseModel
+from typing import Optional, Literal
+from pydantic import BaseModel, constr, confloat
 import logging
 from ccxt.base.errors import ExchangeError, NetworkError
 from app.rate_limiter import limiter
@@ -20,19 +20,19 @@ class WebhookPayload(BaseModel):
         exchange (str): The exchange ID (e.g., 'binance').
         apiKey (str): API key for the exchange.
         secret (str): API secret for the exchange.
-        symbol (str): Trading pair symbol (e.g., 'BTC/USDT').
-        side (str): 'buy' or 'sell'.
-        amount (float): Amount of asset to buy/sell.
-        price (float): Limit price for the order.
+        symbol (str): Trading pair symbol matching ``^[A-Z0-9]+/[A-Z0-9]+$``.
+        side (Literal["buy", "sell"]): Order side.
+        amount (float): Amount of asset to buy/sell (> 0).
+        price (float): Limit price for the order (> 0).
         token (Optional[str]): Fallback auth token (for unsigned clients like TradingView).
     """
     exchange: str
     apiKey: str
     secret: str
-    symbol: str
-    side: str
-    amount: float
-    price: float
+    symbol: constr(pattern="^[A-Z0-9]+/[A-Z0-9]+$")
+    side: Literal["buy", "sell"]
+    amount: confloat(gt=0)
+    price: confloat(gt=0)
     token: Optional[str] = None
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -195,3 +195,71 @@ async def test_signature_reuse_rejected(monkeypatch):
         second = await client.post("/webhook", content=body, headers=headers)
         assert second.status_code == 403
 
+
+@pytest.mark.asyncio
+async def test_invalid_side_rejected():
+    payload = {
+        "token": settings.WEBHOOK_SECRET,
+        "exchange": "binance",
+        "apiKey": "x",
+        "secret": "y",
+        "symbol": "BTC/USDT",
+        "side": "hold",
+        "amount": 0.01,
+        "price": 30000,
+    }
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/webhook", json=payload)
+        assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_invalid_symbol_rejected():
+    payload = {
+        "token": settings.WEBHOOK_SECRET,
+        "exchange": "binance",
+        "apiKey": "x",
+        "secret": "y",
+        "symbol": "BTCUSDT",  # missing slash
+        "side": "buy",
+        "amount": 0.01,
+        "price": 30000,
+    }
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/webhook", json=payload)
+        assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_negative_amount_rejected():
+    payload = {
+        "token": settings.WEBHOOK_SECRET,
+        "exchange": "binance",
+        "apiKey": "x",
+        "secret": "y",
+        "symbol": "BTC/USDT",
+        "side": "buy",
+        "amount": -1,
+        "price": 30000,
+    }
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/webhook", json=payload)
+        assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_zero_price_rejected():
+    payload = {
+        "token": settings.WEBHOOK_SECRET,
+        "exchange": "binance",
+        "apiKey": "x",
+        "secret": "y",
+        "symbol": "BTC/USDT",
+        "side": "buy",
+        "amount": 0.01,
+        "price": 0,
+    }
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/webhook", json=payload)
+        assert response.status_code == 422
+


### PR DESCRIPTION
## Summary
- require side to be `buy` or `sell`
- validate symbol format with regex
- enforce positive amount and price
- add tests for invalid payload fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847135bbaa88331a4707db4bbd8c61b