### PR TITLE
feat: add persistent exchange sessions

### DIFF
--- a/PRODUCTION_CHECKLIST.md
+++ b/PRODUCTION_CHECKLIST.md
@@ -9,6 +9,7 @@
 ## ✅ Reliability
 - [x] Graceful error handling with FastAPI HTTP exceptions
 - [x] Close exchange connections (ccxt.async_support)
+- [x] Reuse CCXT sessions across requests
 - [x] Health check endpoint
 - [ ] Implement retry logic or circuit breaker pattern for exchange errors
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ This project is a production-grade, asynchronous webhook server built with **Fas
 - 🧪 **Full async test suite** with `pytest-asyncio` and mocking
 - ☁️ **Heroku deployment ready**
 - 🚦 **Per-IP rate limiting** via `slowapi`
+- ♻️ **Persistent CCXT sessions** reused across requests
+
+Exchange connections are cached per API key and cleaned up when the
+application shuts down. This avoids the overhead of creating a new CCXT
+client on every webhook call.
 
 ---
 

--- a/app/session_pool.py
+++ b/app/session_pool.py
@@ -1,0 +1,53 @@
+import ccxt.async_support as ccxt
+from fastapi import HTTPException, status
+from typing import Dict, Tuple, Optional
+from config.settings import settings
+
+# Cached exchange instances keyed by (exchange_id, api_key)
+_sessions: Dict[Tuple[str, str], ccxt.Exchange] = {}
+
+async def get_persistent_exchange(exchange_id: str, api_key: Optional[str] = None, secret: Optional[str] = None) -> ccxt.Exchange:
+    """Return a cached ccxt client or create one if missing."""
+    exchange_id = exchange_id.lower()
+    if exchange_id not in ccxt.exchanges:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Exchange '{exchange_id}' is not supported by CCXT."
+        )
+
+    exchange_class = getattr(ccxt, exchange_id)
+    api_key = api_key or settings.DEFAULT_API_KEY
+    secret = secret or settings.DEFAULT_API_SECRET
+
+    if not api_key or not secret:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Missing API credentials for exchange '{exchange_id}'."
+        )
+
+    key = (exchange_id, api_key)
+    if key in _sessions:
+        return _sessions[key]
+
+    try:
+        exchange = exchange_class({
+            'apiKey': api_key,
+            'secret': secret,
+            'options': {'defaultType': 'future'}
+        })
+        _sessions[key] = exchange
+        return exchange
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to initialize exchange '{exchange_id}': {str(e)}"
+        )
+
+async def close_all_sessions() -> None:
+    """Close all cached exchange sessions."""
+    for exchange in list(_sessions.values()):
+        try:
+            await exchange.close()
+        except Exception:
+            pass
+    _sessions.clear()

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from app.rate_limiter import limiter
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
+from app.session_pool import close_all_sessions
 
 app = FastAPI()
 setup_logger()
@@ -19,3 +20,8 @@ app.include_router(webhook_router)
 @app.get("/")
 async def health_check():
     return {"status": "running", "message": "Webhook server ready"}
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await close_all_sessions()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -12,7 +12,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from main import app
 from config.settings import settings
 from httpx import AsyncClient, ASGITransport
-import app.exchange_factory as exchange_factory
+import app.session_pool as session_pool
 import app.routes as routes
 from app.auth import verify_token
 from app.token_store import issue_token, revoke_token
@@ -126,7 +126,7 @@ async def test_invalid_signature():
 @pytest.mark.asyncio
 async def test_get_exchange_invalid_id():
     with pytest.raises(HTTPException) as exc:
-        await exchange_factory.get_exchange("nosuch", "k", "s")
+        await session_pool.get_persistent_exchange("nosuch", "k", "s")
     assert exc.value.status_code == 400
 
 
@@ -166,8 +166,8 @@ async def test_valid_token_order(monkeypatch):
     async def mock_get_exchange(*args, **kwargs):
         return DummyExchange()
 
-    monkeypatch.setattr(exchange_factory, "get_exchange", mock_get_exchange)
-    monkeypatch.setattr(routes, "get_exchange", mock_get_exchange)
+    monkeypatch.setattr(session_pool, "get_persistent_exchange", mock_get_exchange)
+    monkeypatch.setattr(routes, "get_persistent_exchange", mock_get_exchange)
 
     token = issue_token(ttl=30)
     payload = {
@@ -204,8 +204,8 @@ async def test_signature_reuse_rejected(monkeypatch):
     async def mock_get_exchange(*args, **kwargs):
         return DummyExchange()
 
-    monkeypatch.setattr(exchange_factory, "get_exchange", mock_get_exchange)
-    monkeypatch.setattr(routes, "get_exchange", mock_get_exchange)
+    monkeypatch.setattr(session_pool, "get_persistent_exchange", mock_get_exchange)
+    monkeypatch.setattr(routes, "get_persistent_exchange", mock_get_exchange)
 
     payload = {
         "exchange": "binance",


### PR DESCRIPTION
## Summary
- add session pool to reuse ccxt clients
- cache sessions with `get_persistent_exchange`
- use persistent sessions in webhook route and close them on shutdown
- document persistent session handling
- check off reuse item in production checklist

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847285799648331bb0795487489a295