### PR TITLE
Add valid HMAC signature test

### DIFF
--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -180,11 +180,56 @@ async def test_valid_token_order(monkeypatch):
         "amount": 0.01,
         "price": 30000
     }
+
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post("/webhook", json=payload)
         assert response.status_code == 200
         assert response.json()["order"] == dummy_order
     revoke_token(token)
+
+
+@pytest.mark.asyncio
+async def test_valid_signature_order(monkeypatch):
+    dummy_order = {"id": "order1", "status": "filled"}
+
+    class DummyExchange:
+        async def load_markets(self):
+            return {"SOL/USDT": {"type": "future"}}
+
+        async def create_market_order(self, symbol, side, amount):
+            return dummy_order
+
+        async def close(self):
+            pass
+
+    async def mock_get_exchange(*args, **kwargs):
+        return DummyExchange()
+
+    monkeypatch.setattr(exchange_factory, "get_exchange", mock_get_exchange)
+    monkeypatch.setattr(routes, "get_exchange", mock_get_exchange)
+
+    payload = {
+        "exchange": "binance",
+        "apiKey": "x",
+        "secret": "y",
+        "symbol": "BTC/USDT",
+        "side": "buy",
+        "amount": 0.02,
+        "price": 31000,
+    }
+    body = json.dumps(payload).encode()
+    timestamp = str(int(time.time()))
+    signature = hmac.new(settings.WEBHOOK_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    headers = {
+        "X-Signature": signature,
+        "X-Timestamp": timestamp,
+        "Content-Type": "application/json",
+    }
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/webhook", content=body, headers=headers)
+        assert response.status_code == 200
+        assert response.json()["order"] == dummy_order
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add async test for successful HMAC-signed request using monkeypatch to mock exchanges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472cf5d79c8331a6130aacbbfac52d