### PR TITLE
Fix trailing text in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,4 @@ All notable changes to this project will be documented in this file.
 - Full async test suite using `pytest-asyncio` and `httpx`
 - `simulate_tradingview.py` for end-to-end simulation
 - Heroku deployment config: `Procfile`, `runtime.txt`
-- Complete `README.md` with setup, usage, and deployment docs
+- Complete `README.md` with setup, usage, and deployment docs.


### PR DESCRIPTION
## Summary
- correct final changelog entry and add missing newline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6847467caf648331ad767144bc8b5177