### PR TITLE
Improve docstrings

### DIFF
--- a/app/rate_limiter.py
+++ b/app/rate_limiter.py
@@ -1,4 +1,9 @@
+"""Centralized rate limiter configuration for the API."""
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+# Use the client's IP address to identify unique callers
 limiter = Limiter(key_func=get_remote_address)
+
+__all__ = ["limiter"]

--- a/simulate_tradingview.py
+++ b/simulate_tradingview.py
@@ -1,12 +1,25 @@
-import requests
-import time
+"""Utility script that sends a test webhook request.
+
+This module can be run directly to simulate how TradingView would call the
+``/webhook`` endpoint. The payload is intentionally simple and uses dummy API
+credentials.
+"""
+
 import json
+import time
+from typing import Dict
+
+import requests
+
 from app.utils import setup_logger
 
 logger = setup_logger("simulate_tradingview")
 
-url = "http://127.0.0.1:8000/webhook"
-payload = {
+# Target endpoint of the locally running FastAPI app
+URL = "http://127.0.0.1:8000/webhook"
+
+# Minimal example payload accepted by the webhook route
+PAYLOAD: Dict[str, object] = {
     "token": "dummy",
     "exchange": "binance",
     "apiKey": "dummy",
@@ -14,18 +27,33 @@ payload = {
     "symbol": "SOL/USDT",
     "side": "sell",
     "amount": 1,
-    "price": 174.10
+    "price": 174.10,
 }
 
+# Static headers for JSON payloads
+HEADERS = {"Content-Type": "application/json"}
 
-headers = {
-    "Content-Type": "application/json"
-}
 
-start = time.monotonic()
-response = requests.post(url, data=json.dumps(payload), headers=headers)
-end = time.monotonic()
+def send_test_webhook(url: str = URL) -> requests.Response:
+    """Send ``PAYLOAD`` to ``url`` and return the response.
 
-logger.info(f"Status Code: {response.status_code}")
-logger.info(f"Response Time: {end - start:.4f} seconds")
-logger.info("Response Body: %s", response.json())
+    Args:
+        url (str): Address of the webhook endpoint.
+
+    Returns:
+        requests.Response: HTTP response from the server.
+    """
+
+    start = time.monotonic()
+    response = requests.post(url, data=json.dumps(PAYLOAD), headers=HEADERS)
+    end = time.monotonic()
+
+    logger.info("Status Code: %s", response.status_code)
+    logger.info("Response Time: %.4f seconds", end - start)
+    logger.info("Response Body: %s", response.json())
+
+    return response
+
+
+if __name__ == "__main__":
+    send_test_webhook()


### PR DESCRIPTION
## Summary
- document FastAPI setup in `main`
- expand commentary in `simulate_tradingview.py`
- add module docs to rate limiter
- restructure testing utility with a helper function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847542b90248331bcae0fcf5ce371a9