### PR TITLE
Add documentation for async session pool and tasks

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -12,6 +12,15 @@ REQUEST_LATENCY = Histogram(
 
 class MetricsMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
+        """Record request latency and continue processing.
+
+        Args:
+            request: Incoming ``Request`` object.
+            call_next: Function that executes the next middleware/endpoint.
+
+        Returns:
+            Response: The response returned by ``call_next``.
+        """
         start_time = time.perf_counter()
         response = await call_next(request)
         latency = time.perf_counter() - start_time
@@ -19,4 +28,9 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         return response
 
 def metrics():
+    """Expose collected Prometheus metrics as an HTTP response.
+
+    Returns:
+        Response: Metrics in Prometheus text format.
+    """
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -16,7 +16,16 @@ logger = logging.getLogger("webhook_logger")
 
 
 async def _execute_order(payload: dict) -> dict:
-    """Execute an order using CCXT with the given payload."""
+    """Execute a market order asynchronously via CCXT.
+
+    Args:
+        payload: Dictionary containing order parameters. Expected keys are
+            ``exchange``, ``apiKey``, ``secret``, ``symbol``, ``side`` and
+            ``amount``.
+
+    Returns:
+        dict: Raw order data returned by CCXT.
+    """
     exchange = None
     try:
         exchange = await get_exchange(
@@ -40,5 +49,12 @@ async def _execute_order(payload: dict) -> dict:
 
 @celery_app.task(name="place_order")
 def place_order_task(payload: dict) -> dict:
-    """Celery task wrapper to run the async order coroutine."""
+    """Synchronously execute ``_execute_order`` inside a Celery worker.
+
+    Args:
+        payload: Same structure as expected by ``_execute_order``.
+
+    Returns:
+        dict: Order information returned from the exchange.
+    """
     return asyncio.run(_execute_order(payload))


### PR DESCRIPTION
## Summary
- document methods in `ExchangeSessionPool`
- expand docstrings for Celery order tasks
- describe metrics middleware functions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476439618c83318492edca4c0b8245