### PR TITLE
Fix link to deployment docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -226,7 +226,7 @@ python simulate_tradingview.py
 ## 9. ☁️ Deployment (Heroku)
 
 Detailed deployment guides, including Docker Compose and VPS instructions,
-are available in [docs/deployment.md](docs/deployment.md).
+are available in [deployment.md](deployment.md).
 
 
 ### CLI-Based Deployment:


### PR DESCRIPTION
## Summary
- fix relative link to deployment docs in docs/README.md

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6847f8158e688331871f89667e1cc568