### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: pip install mkdocs-material mkdocs-openapi-markdown-plugin
+      - run: pip install mkdocs-material mkdocs-openapi-markdown-plugin openapi-markdown
       - run: mkdocs build
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install dependencies and run the tests:
 ```bash
 pip install -r requirements.txt
 # Extras needed for local documentation builds
-pip install mkdocs-material mkdocs-openapi-markdown-plugin
+pip install mkdocs-material mkdocs-openapi-markdown-plugin openapi-markdown
 pytest
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env
 # Extras required for local documentation builds
-pip install mkdocs-material mkdocs-openapi-markdown-plugin
+pip install mkdocs-material mkdocs-openapi-markdown-plugin openapi-markdown
 ```
 
 These additional packages are needed if you plan to run `mkdocs build` or


### PR DESCRIPTION
## Summary
- install openapi-markdown in the GitHub docs workflow
- update docs instructions to mention `openapi-markdown`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684845eed0e8833180d4e0891931f9da