### PR TITLE
Update design doc links

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,11 +5,12 @@ This page details the major features of the copy-trading webhook platform. The c
 ## Identity (`app.identity`)
 - **Token management** – Issue and revoke API tokens with TTL support.
 - **KYC verification** – Accept document uploads and allow admin approval.
-- [Design Doc](identity-module-design.md) – Detailed architecture and schema.
+ - [Design Doc](identity_module_design.md) – Detailed architecture and schema.
 - [Implementation Plan](identity-implementation-plan.md) – Step-by-step rollout.
 
 ## Wallet (`app.wallet`)
 - **Address CRUD** – Add, list, update, and delete deposit addresses.
+- [Design Doc](wallet_module_design.md) – Exchange address management architecture.
 
 ## Marketplace (`app.marketplace`)
 - **Strategy catalog** – Paginated list of master strategies with search.

--- a/docs/identity-implementation-plan.md
+++ b/docs/identity-implementation-plan.md
@@ -1,6 +1,6 @@
 # Identity Module Implementation Plan
 
-This plan outlines the high‑level steps required to implement the `app.identity` module based on the [design document](identity-module-design.md).
+This plan outlines the high‑level steps required to implement the `app.identity` module based on the [design document](identity_module_design.md).
 
 ## 1. Database Setup
 - Create migrations for the `users`, `api_tokens`, `kyc_verifications` and `kyc_documents` tables.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,8 @@ nav:
   - Reference:
       - API Reference: api-reference.md
   - Design:
-      - Identity Module: identity-module-design.md
+      - Identity Module: identity_module_design.md
+      - Wallet Module: wallet_module_design.md
       - Identity Implementation Plan: identity-implementation-plan.md
   - Deployment:
       - Deployment Guide: deployment.md


### PR DESCRIPTION
## Summary
- point identity doc link at `identity_module_design.md`
- link to wallet design doc in features page
- add wallet module doc to mkdocs nav

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6849e984f7b88331b05a5790696f2790