### PR TITLE
Add identity ORM models and migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///identity.db
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,40 @@
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+import os
+
+from app.db import Base
+import app.identity.models  # noqa: F401
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_create_identity_tables.py
+++ b/alembic/versions/0001_create_identity_tables.py
@@ -1,0 +1,169 @@
+"""create identity tables"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('email', sa.String(255), nullable=False, unique=True),
+        sa.Column('username', sa.String(50), unique=True),
+        sa.Column('password_hash', sa.String(255), nullable=False),
+        sa.Column('first_name', sa.String(100)),
+        sa.Column('last_name', sa.String(100)),
+        sa.Column('phone_number', sa.String(20)),
+        sa.Column('date_of_birth', sa.Date()),
+        sa.Column('country_code', sa.String(2)),
+        sa.Column('timezone', sa.String(50), server_default='UTC'),
+        sa.Column('language', sa.String(10), server_default='en'),
+        sa.Column('profile_picture_url', sa.String(500)),
+        sa.Column('account_type', sa.String(20), server_default='standard'),
+        sa.Column('account_status', sa.String(20), server_default='active'),
+        sa.Column('email_verified', sa.Boolean(), server_default=sa.text('0')),
+        sa.Column('email_verification_token', sa.String(100)),
+        sa.Column('password_reset_token', sa.String(100)),
+        sa.Column('password_reset_expires_at', sa.DateTime()),
+        sa.Column('last_login_at', sa.DateTime()),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+
+    op.create_table(
+        'roles',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('name', sa.String(50), nullable=False, unique=True),
+        sa.Column('display_name', sa.String(100), nullable=False),
+        sa.Column('description', sa.Text()),
+        sa.Column('is_system_role', sa.Boolean(), server_default=sa.text('0')),
+        sa.Column('is_active', sa.Boolean(), server_default=sa.text('1')),
+        sa.Column('hierarchy_level', sa.Integer(), server_default='0'),
+        sa.Column('parent_role_id', sa.String(36), sa.ForeignKey('roles.id')),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+    op.create_index('idx_role_hierarchy', 'roles', ['parent_role_id', 'hierarchy_level'])
+
+    op.create_table(
+        'permissions',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('name', sa.String(100), nullable=False, unique=True),
+        sa.Column('display_name', sa.String(150), nullable=False),
+        sa.Column('description', sa.Text()),
+        sa.Column('category', sa.String(50), nullable=False),
+        sa.Column('resource', sa.String(50), nullable=False),
+        sa.Column('action', sa.String(50), nullable=False),
+        sa.Column('is_active', sa.Boolean(), server_default=sa.text('1')),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+    op.create_index('idx_permission_resource', 'permissions', ['resource', 'action'])
+
+    op.create_table(
+        'role_permissions',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('role_id', sa.String(36), sa.ForeignKey('roles.id'), nullable=False),
+        sa.Column('permission_id', sa.String(36), sa.ForeignKey('permissions.id'), nullable=False),
+        sa.Column('granted_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('granted_by', sa.String(36), sa.ForeignKey('users.id')),
+    )
+    op.create_index('idx_role_perms', 'role_permissions', ['role_id'])
+    op.create_index('idx_perm_roles', 'role_permissions', ['permission_id'])
+
+    op.create_table(
+        'user_roles',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('user_id', sa.String(36), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('role_id', sa.String(36), sa.ForeignKey('roles.id'), nullable=False),
+        sa.Column('assigned_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('assigned_by', sa.String(36), sa.ForeignKey('users.id')),
+        sa.Column('expires_at', sa.DateTime()),
+        sa.Column('is_active', sa.Boolean(), server_default=sa.text('1')),
+    )
+    op.create_index('idx_user_roles', 'user_roles', ['user_id', 'is_active'])
+    op.create_index('idx_role_users', 'user_roles', ['role_id', 'is_active'])
+
+    op.create_table(
+        'api_tokens',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('user_id', sa.String(36), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('token_hash', sa.String(64), nullable=False, unique=True),
+        sa.Column('token_name', sa.String(100), nullable=False),
+        sa.Column('token_type', sa.String(20), nullable=False),
+        sa.Column('permissions', sa.JSON(), nullable=False, server_default='{}'),
+        sa.Column('role_restrictions', sa.JSON(), server_default='{}'),
+        sa.Column('expires_at', sa.DateTime()),
+        sa.Column('last_used_at', sa.DateTime()),
+        sa.Column('is_revoked', sa.Boolean(), server_default=sa.text('0')),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+
+    op.create_table(
+        'kyc_verifications',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('user_id', sa.String(36), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('kyc_level', sa.String(20), nullable=False, server_default='basic'),
+        sa.Column('status', sa.String(20), nullable=False, server_default='pending'),
+        sa.Column('submitted_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('reviewed_at', sa.DateTime()),
+        sa.Column('reviewed_by', sa.String(36), sa.ForeignKey('users.id')),
+        sa.Column('rejection_reason', sa.Text()),
+        sa.Column('compliance_score', sa.Integer()),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+
+    op.create_table(
+        'kyc_documents',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('kyc_verification_id', sa.String(36), sa.ForeignKey('kyc_verifications.id'), nullable=False),
+        sa.Column('document_type', sa.String(50), nullable=False),
+        sa.Column('file_path', sa.String(500), nullable=False),
+        sa.Column('file_size', sa.Integer(), nullable=False),
+        sa.Column('mime_type', sa.String(100), nullable=False),
+        sa.Column('encryption_key_id', sa.String(100), nullable=False),
+        sa.Column('ocr_data', sa.JSON()),
+        sa.Column('validation_status', sa.String(20), server_default='pending'),
+        sa.Column('uploaded_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+
+    op.create_table(
+        'permission_audit_log',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('user_id', sa.String(36), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('action', sa.String(50), nullable=False),
+        sa.Column('resource', sa.String(100), nullable=False),
+        sa.Column('permission_checked', sa.String(100)),
+        sa.Column('access_granted', sa.Boolean(), nullable=False),
+        sa.Column('role_context', sa.JSON()),
+        sa.Column('ip_address', sa.String(45)),
+        sa.Column('user_agent', sa.Text()),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+    op.create_index('idx_audit_user', 'permission_audit_log', ['user_id', 'created_at'])
+    op.create_index('idx_audit_resource', 'permission_audit_log', ['resource', 'created_at'])
+
+
+def downgrade() -> None:
+    op.drop_index('idx_audit_resource', table_name='permission_audit_log')
+    op.drop_index('idx_audit_user', table_name='permission_audit_log')
+    op.drop_table('permission_audit_log')
+    op.drop_table('kyc_documents')
+    op.drop_table('kyc_verifications')
+    op.drop_table('api_tokens')
+    op.drop_index('idx_role_users', table_name='user_roles')
+    op.drop_index('idx_user_roles', table_name='user_roles')
+    op.drop_table('user_roles')
+    op.drop_index('idx_perm_roles', table_name='role_permissions')
+    op.drop_index('idx_role_perms', table_name='role_permissions')
+    op.drop_table('role_permissions')
+    op.drop_index('idx_permission_resource', table_name='permissions')
+    op.drop_table('permissions')
+    op.drop_index('idx_role_hierarchy', table_name='roles')
+    op.drop_table('roles')
+    op.drop_table('users')

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,7 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from config.settings import settings
+
+engine = create_engine(settings.DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+Base = declarative_base()

--- a/app/identity/models.py
+++ b/app/identity/models.py
@@ -1,0 +1,209 @@
+import uuid
+import secrets
+import hashlib
+from sqlalchemy import (
+    Column, String, Integer, Boolean, DateTime, Date, ForeignKey, JSON, Text, Index
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from passlib.context import CryptContext
+from app.db import Base
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+class TimestampMixin:
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class User(Base, TimestampMixin):
+    __tablename__ = "users"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    email = Column(String(255), nullable=False, unique=True)
+    username = Column(String(50), unique=True)
+    password_hash = Column(String(255), nullable=False)
+    first_name = Column(String(100))
+    last_name = Column(String(100))
+    phone_number = Column(String(20))
+    date_of_birth = Column(Date)
+    country_code = Column(String(2))
+    timezone = Column(String(50), default="UTC")
+    language = Column(String(10), default="en")
+    profile_picture_url = Column(String(500))
+    account_type = Column(String(20), default="standard")
+    account_status = Column(String(20), default="active")
+    email_verified = Column(Boolean, default=False)
+    email_verification_token = Column(String(100))
+    password_reset_token = Column(String(100))
+    password_reset_expires_at = Column(DateTime(timezone=True))
+    last_login_at = Column(DateTime(timezone=True))
+
+    roles = relationship("UserRole", back_populates="user")
+    tokens = relationship("ApiToken", back_populates="user")
+    kyc_verifications = relationship("KycVerification", back_populates="user")
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = pwd_context.hash(password)
+
+    def verify_password(self, password: str) -> bool:
+        return pwd_context.verify(password, self.password_hash)
+
+
+class Role(Base, TimestampMixin):
+    __tablename__ = "roles"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    name = Column(String(50), nullable=False, unique=True)
+    display_name = Column(String(100), nullable=False)
+    description = Column(Text)
+    is_system_role = Column(Boolean, default=False)
+    is_active = Column(Boolean, default=True)
+    hierarchy_level = Column(Integer, default=0)
+    parent_role_id = Column(String(36), ForeignKey("roles.id"))
+
+    parent = relationship("Role", remote_side=[id])
+    permissions = relationship("RolePermission", back_populates="role")
+
+    __table_args__ = (
+        Index("idx_role_hierarchy", "parent_role_id", "hierarchy_level"),
+    )
+
+
+class Permission(Base, TimestampMixin):
+    __tablename__ = "permissions"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    name = Column(String(100), nullable=False, unique=True)
+    display_name = Column(String(150), nullable=False)
+    description = Column(Text)
+    category = Column(String(50), nullable=False)
+    resource = Column(String(50), nullable=False)
+    action = Column(String(50), nullable=False)
+    is_active = Column(Boolean, default=True)
+
+    roles = relationship("RolePermission", back_populates="permission")
+
+    __table_args__ = (
+        Index("idx_permission_resource", "resource", "action"),
+    )
+
+
+class RolePermission(Base):
+    __tablename__ = "role_permissions"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    role_id = Column(String(36), ForeignKey("roles.id"), nullable=False)
+    permission_id = Column(String(36), ForeignKey("permissions.id"), nullable=False)
+    granted_at = Column(DateTime(timezone=True), server_default=func.now())
+    granted_by = Column(String(36), ForeignKey("users.id"))
+
+    role = relationship("Role", back_populates="permissions")
+    permission = relationship("Permission", back_populates="roles")
+
+    __table_args__ = (
+        Index("idx_role_perms", "role_id"),
+        Index("idx_perm_roles", "permission_id"),
+    )
+
+
+class UserRole(Base):
+    __tablename__ = "user_roles"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
+    role_id = Column(String(36), ForeignKey("roles.id"), nullable=False)
+    assigned_at = Column(DateTime(timezone=True), server_default=func.now())
+    assigned_by = Column(String(36), ForeignKey("users.id"))
+    expires_at = Column(DateTime(timezone=True))
+    is_active = Column(Boolean, default=True)
+
+    user = relationship("User", back_populates="roles", foreign_keys=[user_id])
+    role = relationship("Role")
+
+    __table_args__ = (
+        Index("idx_user_roles", "user_id", "is_active"),
+        Index("idx_role_users", "role_id", "is_active"),
+        {"sqlite_autoincrement": True},
+    )
+
+
+class ApiToken(Base, TimestampMixin):
+    __tablename__ = "api_tokens"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
+    token_hash = Column(String(64), nullable=False, unique=True)
+    token_name = Column(String(100), nullable=False)
+    token_type = Column(String(20), nullable=False)
+    permissions = Column(JSON, nullable=False, default=dict)
+    role_restrictions = Column(JSON, default=dict)
+    expires_at = Column(DateTime(timezone=True))
+    last_used_at = Column(DateTime(timezone=True))
+    is_revoked = Column(Boolean, default=False)
+
+    user = relationship("User", back_populates="tokens")
+
+    def generate_token(self) -> str:
+        raw = secrets.token_hex(32)
+        self.token_hash = hash_token(raw)
+        return raw
+
+
+class KycVerification(Base, TimestampMixin):
+    __tablename__ = "kyc_verifications"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
+    kyc_level = Column(String(20), nullable=False, default="basic")
+    status = Column(String(20), nullable=False, default="pending")
+    submitted_at = Column(DateTime(timezone=True), server_default=func.now())
+    reviewed_at = Column(DateTime(timezone=True))
+    reviewed_by = Column(String(36), ForeignKey("users.id"))
+    rejection_reason = Column(Text)
+    compliance_score = Column(Integer)
+
+    user = relationship("User", back_populates="kyc_verifications")
+    documents = relationship("KycDocument", back_populates="verification")
+
+
+class KycDocument(Base):
+    __tablename__ = "kyc_documents"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    kyc_verification_id = Column(String(36), ForeignKey("kyc_verifications.id"), nullable=False)
+    document_type = Column(String(50), nullable=False)
+    file_path = Column(String(500), nullable=False)
+    file_size = Column(Integer, nullable=False)
+    mime_type = Column(String(100), nullable=False)
+    encryption_key_id = Column(String(100), nullable=False)
+    ocr_data = Column(JSON)
+    validation_status = Column(String(20), default="pending")
+    uploaded_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    verification = relationship("KycVerification", back_populates="documents")
+
+
+class PermissionAuditLog(Base):
+    __tablename__ = "permission_audit_log"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String(36), ForeignKey("users.id"), nullable=False)
+    action = Column(String(50), nullable=False)
+    resource = Column(String(100), nullable=False)
+    permission_checked = Column(String(100))
+    access_granted = Column(Boolean, nullable=False)
+    role_context = Column(JSON)
+    ip_address = Column(String(45))
+    user_agent = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        Index("idx_audit_user", "user_id", "created_at"),
+        Index("idx_audit_resource", "resource", "created_at"),
+    )

--- a/config/settings.py
+++ b/config/settings.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     QUEUE_ORDERS: bool = False
     STATIC_API_KEY: str = ""
     REQUIRE_API_KEY: bool = False
+    DATABASE_URL: str = "sqlite:///identity.db"
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ python-json-logger~=2.0
 prometheus_client~=0.20
 celery~=5.3
 tenacity~=8.2
+SQLAlchemy~=2.0
+alembic~=1.16
+passlib[bcrypt]~=1.7


### PR DESCRIPTION
## Summary
- define DB connection utilities
- implement SQLAlchemy models with password and token hashing helpers
- add initial Alembic environment and migration
- add database URL setting and requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f9b0fa4c833187f4a481bc9686b7