### PR TITLE
Add identity registration and auth endpoints

### DIFF
--- a/app/identity/models.py
+++ b/app/identity/models.py
@@ -44,9 +44,9 @@ class User(Base, TimestampMixin):
     password_reset_expires_at = Column(DateTime(timezone=True))
     last_login_at = Column(DateTime(timezone=True))
 
-    roles = relationship("UserRole", back_populates="user")
+    roles = relationship("UserRole", back_populates="user", foreign_keys="UserRole.user_id")
     tokens = relationship("ApiToken", back_populates="user")
-    kyc_verifications = relationship("KycVerification", back_populates="user")
+    kyc_verifications = relationship("KycVerification", back_populates="user", foreign_keys="KycVerification.user_id")
 
     def set_password(self, password: str) -> None:
         self.password_hash = pwd_context.hash(password)
@@ -168,7 +168,7 @@ class KycVerification(Base, TimestampMixin):
     rejection_reason = Column(Text)
     compliance_score = Column(Integer)
 
-    user = relationship("User", back_populates="kyc_verifications")
+    user = relationship("User", back_populates="kyc_verifications", foreign_keys=[user_id])
     documents = relationship("KycDocument", back_populates="verification")
 
 

--- a/app/identity/routes.py
+++ b/app/identity/routes.py
@@ -1,0 +1,127 @@
+from fastapi import APIRouter, HTTPException, Depends, status
+from pydantic import BaseModel, EmailStr
+from sqlalchemy.orm import Session
+from datetime import datetime, timedelta
+from app.db import SessionLocal
+from .models import User
+from .auth import create_jwt, decode_jwt, get_current_user
+import secrets
+
+router = APIRouter(prefix="/api/v1/identity", tags=["identity"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+class RegisterPayload(BaseModel):
+    email: EmailStr
+    password: str | None = None
+    username: str | None = None
+    registration_type: str | None = "standard"  # standard | social | demo
+
+
+class VerifyEmailPayload(BaseModel):
+    token: str
+
+
+class LoginPayload(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class ForgotPayload(BaseModel):
+    email: EmailStr
+
+
+class ResetPayload(BaseModel):
+    token: str
+    new_password: str
+
+
+@router.post("/register")
+def register(payload: RegisterPayload, db: Session = Depends(get_db)):
+    if db.query(User).filter(User.email == payload.email).first():
+        raise HTTPException(status_code=400, detail="Email already registered")
+    user = User(email=payload.email, username=payload.username)
+
+    if payload.registration_type == "demo":
+        user.account_type = "demo"
+        user.email_verified = True
+        user.set_password(secrets.token_hex(8))
+    elif payload.registration_type == "social":
+        user.account_type = "social"
+        user.email_verified = True
+        user.set_password(secrets.token_hex(8))
+    else:
+        if not payload.password:
+            raise HTTPException(status_code=400, detail="Password required")
+        user.set_password(payload.password)
+        token = create_jwt(user.email, expires_in=3600)
+        user.email_verification_token = token
+
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return {"user_id": user.id, "email_verification_token": user.email_verification_token}
+
+
+@router.post("/verify-email")
+def verify_email(payload: VerifyEmailPayload, db: Session = Depends(get_db)):
+    email = decode_jwt(payload.token)
+    if not email:
+        raise HTTPException(status_code=400, detail="Invalid token")
+    user = db.query(User).filter(User.email_verification_token == payload.token).first()
+    if not user:
+        raise HTTPException(status_code=400, detail="Invalid token")
+    user.email_verified = True
+    user.email_verification_token = None
+    db.commit()
+    return {"message": "email verified"}
+
+
+@router.post("/login")
+def login(payload: LoginPayload, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == payload.email).first()
+    if not user or not user.verify_password(payload.password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    token = create_jwt(user.id, expires_in=86400)
+    user.last_login_at = datetime.utcnow()
+    db.commit()
+    return {"access_token": token, "token_type": "bearer"}
+
+
+@router.post("/logout")
+def logout(current: User = Depends(get_current_user)):
+    return {"message": "logged out"}
+
+
+@router.post("/forgot-password")
+def forgot_password(payload: ForgotPayload, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == payload.email).first()
+    if not user:
+        return {"message": "ok"}
+    token = create_jwt(user.id, expires_in=3600)
+    user.password_reset_token = token
+    user.password_reset_expires_at = datetime.utcnow() + timedelta(hours=1)
+    db.commit()
+    return {"reset_token": token}
+
+
+@router.post("/reset-password")
+def reset_password(payload: ResetPayload, db: Session = Depends(get_db)):
+    user_id = decode_jwt(payload.token)
+    if not user_id:
+        raise HTTPException(status_code=400, detail="Invalid token")
+    user = db.query(User).filter(User.password_reset_token == payload.token).first()
+    if not user or not user.password_reset_expires_at or user.password_reset_expires_at < datetime.utcnow():
+        raise HTTPException(status_code=400, detail="Invalid or expired token")
+    user.set_password(payload.new_password)
+    user.password_reset_token = None
+    user.password_reset_expires_at = None
+    db.commit()
+    return {"message": "password updated"}

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ webhook service.
 
 from fastapi import FastAPI
 from app.api.routes import router as webhook_router
+from app.identity.routes import router as identity_router
 import logging
 from app.utils import setup_logger
 from app.rate_limiter import limiter
@@ -27,6 +28,7 @@ app.add_middleware(MetricsMiddleware)
 
 # Mount application routes
 app.include_router(webhook_router)
+app.include_router(identity_router)
 
 @app.get("/")
 async def health_check() -> dict:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ tenacity~=8.2
 SQLAlchemy~=2.0
 alembic~=1.16
 passlib[bcrypt]~=1.7
+PyJWT~=2.8
+email-validator~=2.1

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Ensure a temporary SQLite DB is used for tests
+os.environ.setdefault("WEBHOOK_SECRET", "testsecret")
+os.environ.setdefault("DEFAULT_EXCHANGE", "binance")
+os.environ.setdefault("DEFAULT_API_KEY", "key")
+os.environ.setdefault("DEFAULT_API_SECRET", "secret")
+os.environ["DATABASE_URL"] = "sqlite:///test_identity.db"
+
+from main import app
+from app.db import Base, engine
+
+if os.path.exists('test_identity.db'):
+    os.remove('test_identity.db')
+Base.metadata.create_all(engine)
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+    yield
+    Base.metadata.drop_all(engine)
+
+transport = ASGITransport(app=app)
+
+@pytest.mark.asyncio
+async def test_register_verify_login_flow(tmp_path):
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/identity/register", json={"email": "a@example.com", "password": "pass"})
+        assert resp.status_code == 200
+        token = resp.json()["email_verification_token"]
+        resp = await client.post("/api/v1/identity/verify-email", json={"token": token})
+        assert resp.status_code == 200
+        resp = await client.post("/api/v1/identity/login", json={"email": "a@example.com", "password": "pass"})
+        assert resp.status_code == 200
+        assert "access_token" in resp.json()
+        reset_resp = await client.post("/api/v1/identity/forgot-password", json={"email": "a@example.com"})
+        reset_token = reset_resp.json()["reset_token"]
+        resp = await client.post("/api/v1/identity/reset-password", json={"token": reset_token, "new_password": "newpass"})
+        assert resp.status_code == 200
+        resp = await client.post("/api/v1/identity/login", json={"email": "a@example.com", "password": "newpass"})
+        assert resp.status_code == 200
+


### PR DESCRIPTION
## Summary
- add JWT utilities for user auth
- implement identity routes for registration, login and password management
- include router in main app
- fix SQLAlchemy relationships
- add email-validator & PyJWT dependencies
- test registration/login/reset flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a005c998483318e4f114a38630c3c