### PR TITLE
Implement RBAC middleware and endpoints

### DIFF
--- a/app/identity/permissions.py
+++ b/app/identity/permissions.py
@@ -1,0 +1,81 @@
+from fastapi import Request, HTTPException
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+from sqlalchemy.orm import Session
+from typing import Callable, Tuple
+
+from app.db import SessionLocal
+from .models import User, UserRole, RolePermission, Permission, PermissionAuditLog
+from .auth import decode_jwt, http_bearer
+
+
+def permission_required(resource: str, action: str) -> Callable:
+    """Decorator to mark endpoints with required permission."""
+
+    def decorator(func: Callable) -> Callable:
+        setattr(func, "required_permission", (resource, action))
+        return func
+
+    return decorator
+
+
+class PermissionMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        from starlette.routing import Match
+        perm: Tuple[str, str] | None = None
+        for route in request.app.router.routes:
+            match, _ = route.matches(request.scope)
+            if match == Match.FULL:
+                if hasattr(route, "endpoint") and hasattr(route.endpoint, "required_permission"):
+                    perm = getattr(route.endpoint, "required_permission")
+                break
+        if not perm:
+            return await call_next(request)
+
+        # Authenticate user via bearer token
+        credentials = await http_bearer(request)
+        user_id = decode_jwt(credentials.credentials)
+        if not user_id:
+            return JSONResponse(status_code=401, content={"detail": "Invalid token"})
+
+        db: Session = SessionLocal()
+        try:
+            user = db.query(User).filter(User.id == user_id).first()
+            if not user:
+                return JSONResponse(status_code=401, content={"detail": "User not found"})
+
+            resource, action = perm
+            role_ids = [ur.role_id for ur in db.query(UserRole)
+                        .filter(UserRole.user_id == user.id, UserRole.is_active == True)
+                        .all()]
+            allowed = False
+            if role_ids:
+                allowed = (
+                    db.query(RolePermission)
+                    .join(Permission, RolePermission.permission_id == Permission.id)
+                    .filter(
+                        RolePermission.role_id.in_(role_ids),
+                        Permission.resource == resource,
+                        Permission.action == action,
+                    )
+                    .count()
+                    > 0
+                )
+            log = PermissionAuditLog(
+                user_id=user.id,
+                action=action,
+                resource=resource,
+                permission_checked=f"{resource}:{action}",
+                access_granted=allowed,
+                role_context={"roles": role_ids},
+                ip_address=request.client.host if request.client else None,
+                user_agent=request.headers.get("User-Agent"),
+            )
+            db.add(log)
+            db.commit()
+            if not allowed:
+                return JSONResponse(status_code=403, content={"detail": "Insufficient permissions"})
+        finally:
+            db.close()
+
+        return await call_next(request)

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from app.dashboard.metrics import MetricsMiddleware, metrics
+from app.identity.permissions import PermissionMiddleware
 
 # Initialize application and configure logging
 app = FastAPI()
@@ -25,6 +26,7 @@ app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIMiddleware)
 app.add_middleware(MetricsMiddleware)
+app.add_middleware(PermissionMiddleware)
 
 # Mount application routes
 app.include_router(webhook_router)

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+os.environ.setdefault("WEBHOOK_SECRET", "testsecret")
+os.environ.setdefault("DEFAULT_EXCHANGE", "binance")
+os.environ.setdefault("DEFAULT_API_KEY", "key")
+os.environ.setdefault("DEFAULT_API_SECRET", "secret")
+os.environ["DATABASE_URL"] = "sqlite:///test_rbac.db"
+
+from main import app
+from sqlalchemy import text
+from app.db import Base, engine, SessionLocal
+from app.identity.models import Permission, Role, RolePermission, UserRole
+
+if os.path.exists('test_rbac.db'):
+    os.remove('test_rbac.db')
+Base.metadata.create_all(engine)
+
+transport = ASGITransport(app=app)
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+    yield
+    Base.metadata.drop_all(engine)
+
+async def register_and_login(client):
+    resp = await client.post("/api/v1/identity/register", json={"email": "u@example.com", "password": "pw"})
+    token = resp.json()["email_verification_token"]
+    user_id = resp.json()["user_id"]
+    await client.post("/api/v1/identity/verify-email", json={"token": token})
+    resp = await client.post("/api/v1/identity/login", json={"email": "u@example.com", "password": "pw"})
+    return user_id, resp.json()["access_token"]
+
+@pytest.mark.asyncio
+async def test_permission_middleware():
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        user_id, token = await register_and_login(client)
+
+        # Attempt to list roles without permission
+        resp = await client.get("/api/v1/identity/roles", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 403
+
+        # Set up permission and role directly in DB
+        with SessionLocal() as db:
+            perm = Permission(name="role_read", display_name="Role Read", category="role", resource="role_management", action="read")
+            db.add(perm)
+            db.commit()
+            db.refresh(perm)
+            role = Role(name="admin", display_name="Admin")
+            db.add(role)
+            db.commit()
+            db.refresh(role)
+            rp = RolePermission(role_id=role.id, permission_id=perm.id)
+            db.add(rp)
+            db.commit()
+            ur = UserRole(user_id=user_id, role_id=role.id)
+            db.add(ur)
+            db.commit()
+
+        resp = await client.get("/api/v1/identity/roles", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        # Check audit log entries
+        with SessionLocal() as db:
+            count = db.execute(text("select count(*) from permission_audit_log")).fetchone()[0]
+            assert count == 2


### PR DESCRIPTION
## Summary
- add `PermissionMiddleware` and `permission_required` decorator
- register middleware in `main.py`
- implement role/permission CRUD routes and user-role assignment
- test permission checks and audit logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a05e2fd988331bb39a1a1200256a6