### PR TITLE
Add python-multipart dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ alembic~=1.16
 passlib[bcrypt]~=1.7
 PyJWT~=2.8
 email-validator~=2.1
+python-multipart~=0.0.7


### PR DESCRIPTION
## Summary
- include python-multipart in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0862867c83318c1d8da8ad95f6b5