### PR TITLE
Add identity token management APIs

### DIFF
--- a/app/identity/auth.py
+++ b/app/identity/auth.py
@@ -13,6 +13,10 @@ import time
 from fastapi import Request, HTTPException, status, Depends
 from config.settings import settings
 from .token_store import is_token_valid, register_nonce
+from datetime import datetime
+from app.db import SessionLocal
+from .models import ApiToken, UserRole, TokenUsageLog, hash_token
+from sqlalchemy.exc import OperationalError
 import logging
 from typing import Optional, Dict
 
@@ -24,6 +28,36 @@ MAX_TIMESTAMP_AGE = 300  # 5 minutes
 # Simple in-memory cache to track recently seen request signatures
 signature_cache: Dict[str, float] = {}
 
+# In-memory token rate tracking {token_hash: [timestamps]}
+token_rate_cache: Dict[str, list[float]] = {}
+
+
+def _parse_rate(rate: str) -> tuple[int, float]:
+    count, per = rate.split("/")
+    count = int(count)
+    seconds = {
+        "second": 1,
+        "minute": 60,
+        "hour": 3600,
+    }.get(per, 60)
+    return count, seconds
+
+
+TOKEN_RATE_LIMIT = _parse_rate(settings.RATE_LIMIT)
+
+
+def _enforce_token_limit(token_hash: str) -> bool:
+    limit, period = TOKEN_RATE_LIMIT
+    now = time.time()
+    usage = token_rate_cache.get(token_hash, [])
+    usage = [t for t in usage if now - t < period]
+    if len(usage) >= limit:
+        return False
+    usage.append(now)
+    token_rate_cache[token_hash] = usage
+    return True
+
+
 async def require_api_key(request: Request) -> None:
     """Optional header-based API key authentication."""
     if not settings.REQUIRE_API_KEY:
@@ -31,7 +65,10 @@ async def require_api_key(request: Request) -> None:
     api_key = request.headers.get("X-API-Key")
     if not api_key or api_key != settings.STATIC_API_KEY:
         logger.warning("Invalid or missing API key")
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key"
+        )
+
 
 async def verify_signature(request: Request) -> bool:
     """
@@ -58,9 +95,7 @@ async def verify_signature(request: Request) -> bool:
         # Generate expected signature from raw request body
         body = await request.body()
         expected_signature = hmac.new(
-            key=settings.WEBHOOK_SECRET.encode(),
-            msg=body,
-            digestmod=hashlib.sha256
+            key=settings.WEBHOOK_SECRET.encode(), msg=body, digestmod=hashlib.sha256
         ).hexdigest()
 
         if not hmac.compare_digest(expected_signature, signature_header):
@@ -88,7 +123,10 @@ async def verify_signature(request: Request) -> bool:
         logger.exception("Unexpected error during signature verification")
         return False
 
-def verify_token(token: Optional[str], nonce: Optional[str]) -> bool:
+
+def verify_token(
+    token: Optional[str], nonce: Optional[str], request: Optional[Request] = None
+) -> bool:
     """
     Verifies a simple token against the shared secret (used by fallback systems).
 
@@ -103,15 +141,61 @@ def verify_token(token: Optional[str], nonce: Optional[str]) -> bool:
         logger.warning("Missing token or nonce in fallback mode")
         return False
 
-    if not is_token_valid(token):
-        logger.warning("Invalid or expired token in fallback mode")
+    if is_token_valid(token):
+        if not register_nonce(nonce):
+            logger.warning("Replay attack detected: nonce reuse")
+            return False
+        return True
+
+    token_hash = hash_token(token)
+    try:
+        with SessionLocal() as db:
+            api_token: ApiToken | None = (
+                db.query(ApiToken)
+                .filter(ApiToken.token_hash == token_hash, ApiToken.is_revoked == False)
+                .first()
+            )
+            if not api_token:
+                logger.warning("Invalid or expired token in fallback mode")
+                return False
+            if api_token.expires_at and api_token.expires_at < datetime.utcnow():
+                logger.warning("Expired API token")
+                return False
+            if not _enforce_token_limit(token_hash):
+                logger.warning("Token rate limit exceeded")
+                return False
+            if not register_nonce(nonce):
+                logger.warning("Replay attack detected: nonce reuse")
+                return False
+            if api_token.role_restrictions:
+                roles = api_token.role_restrictions.get("roles", [])
+                if roles:
+                    count = (
+                        db.query(UserRole)
+                        .filter(
+                            UserRole.user_id == api_token.user_id,
+                            UserRole.role_id.in_(roles),
+                            UserRole.is_active == True,
+                        )
+                        .count()
+                    )
+                    if count == 0:
+                        logger.warning("Token role restriction failed")
+                        return False
+            api_token.last_used_at = datetime.utcnow()
+            log = TokenUsageLog(
+                token_id=api_token.id,
+                user_id=api_token.user_id,
+                ip_address=request.client.host if request and request.client else None,
+                user_agent=request.headers.get("User-Agent") if request else None,
+            )
+            db.add(log)
+            db.commit()
+            return True
+    except OperationalError:
+        logger.error("Token database not initialized")
         return False
 
-    if not register_nonce(nonce):
-        logger.warning("Replay attack detected: nonce reuse")
-        return False
-
-    return True
 
 # JWT utilities for login sessions and email verification
 import jwt
@@ -137,14 +221,22 @@ def decode_jwt(token: str) -> Optional[str]:
         return None
 
 
-def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(http_bearer)) -> User:
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(http_bearer),
+) -> User:
     if not credentials:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing token"
+        )
     user_id = decode_jwt(credentials.credentials)
     if not user_id:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
     with SessionLocal() as db:
         user = db.query(User).filter(User.id == user_id).first()
         if not user:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
+            )
         return user


### PR DESCRIPTION
## Summary
- create `TokenUsageLog` model
- add hashed API token issuance and management routes
- enforce per-token rate limit and role restrictions in auth
- log token usage
- test token CRUD flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0bc37e8c8331bf3626fd1299938d