### PR TITLE
Add compliance report endpoint

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -33,4 +33,5 @@ This page details the major features of the copy-trading webhook platform. The c
 
 ## Compliance (`app.compliance`)
 - **Audit logs** – Track token issuance and nonce usage with cleanup and export options.
+- **Compliance report** – Aggregates KYC status and permission audit data via `/admin/identity/compliance`.
 

--- a/docs/identity-module-design.md
+++ b/docs/identity-module-design.md
@@ -190,6 +190,9 @@ PUT    /api/v1/admin/identity/kyc/{id}/reject  - Reject KYC
 GET    /api/v1/admin/identity/compliance    - Compliance reporting
 ```
 
+The compliance report aggregates overall KYC status counts and summarizes
+permission audit log activity for administrators.
+
 ### 5. Security Considerations
 
 #### 5.1 Token Security


### PR DESCRIPTION
## Summary
- implement `/admin/identity/compliance` to aggregate KYC and permission audit stats
- document compliance report feature
- test compliance report access

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1112dffc83319857680bc8823321